### PR TITLE
fix(notify): ignore transient WebSocket errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to agent-stuff are documented here.
 ## Unreleased
 
 * Fixed the notify extension leaking OSC 8 hyperlink text into fullscreen prompt editors.
+* Fixed the notify extension sending desktop notifications for Pi's transient WebSocket errors.
 
 ## 1.6.0
 

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -22,6 +22,21 @@ const notify = (title: string, body: string): void => {
 const isTextPart = (part: unknown): part is { type: "text"; text: string } =>
 	Boolean(part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part);
 
+const isTransientWebSocketError = (
+	messages: Array<{ role?: string; stopReason?: string; errorMessage?: string }>,
+): boolean => {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message?.role !== "assistant") {
+			continue;
+		}
+
+		return message.stopReason === "error" && message.errorMessage === "WebSocket error";
+	}
+
+	return false;
+};
+
 const extractLastAssistantText = (messages: Array<{ role?: string; content?: unknown }>): string | null => {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i];
@@ -88,7 +103,12 @@ const formatNotification = (text: string | null): { title: string; body: string 
 
 export default function (pi: ExtensionAPI) {
 	pi.on("agent_end", async (event) => {
-		const lastText = extractLastAssistantText(event.messages ?? []);
+		const messages = event.messages ?? [];
+		if (isTransientWebSocketError(messages)) {
+			return;
+		}
+
+		const lastText = extractLastAssistantText(messages);
 		const { title, body } = formatNotification(lastText);
 		notify(title, body);
 	});


### PR DESCRIPTION
## Goal

Avoid sending a desktop notification when Pi ends a low-level agent run with its transient WebSocket transport error.

## Approach

- Check the last assistant message's structured stop reason and error message.
- Suppress only the exact `WebSocket error` transport failure.
- Preserve notifications for unrelated agent errors.

## Validation

- Exercised transient and unrelated error events through the extension's registered `agent_end` handler
- TypeScript type check for the notify extension
- Pi extension load through `pi --list-models --extension ./extensions/notify.ts`
- `npm pack --dry-run`

## Risk

The filter is intentionally exact. Other WebSocket error messages continue to notify.
