### PR TITLE
fix(native-web-search): use current built-in model catalog API

### DIFF
--- a/skills/native-web-search/SKILL.md
+++ b/skills/native-web-search/SKILL.md
@@ -44,6 +44,6 @@ The script instructs the model to:
 ## Notes
 
 - No extra npm install is required.
-- If module resolution fails, set `PI_AI_MODULE_PATH` to `@earendil-works/pi-ai`'s `dist/index.js` path.
+- If module resolution fails, set `PI_AI_MODULE_PATH` to `@earendil-works/pi-ai`'s `dist/providers/all.js` path.
 - If OAuth helper resolution fails, set `PI_AI_OAUTH_MODULE_PATH` to `@earendil-works/pi-ai`'s `dist/oauth.js` path.
 - For OAuth providers, the script can fall back to a still-valid cached `access` token from `~/.pi/agent/auth.json`.

--- a/skills/native-web-search/search.mjs
+++ b/skills/native-web-search/search.mjs
@@ -207,12 +207,12 @@ async function loadPiAi() {
 	const tried = [];
 
 	try {
-		return await import("@earendil-works/pi-ai");
+		return await import("@earendil-works/pi-ai/providers/all");
 	} catch (err) {
-		tried.push(`@earendil-works/pi-ai (${err?.code || err?.message || "not found"})`);
+		tried.push(`@earendil-works/pi-ai/providers/all (${err?.code || err?.message || "not found"})`);
 	}
 
-	for (const candidate of collectModuleCandidates("index.js", "PI_AI_MODULE_PATH")) {
+	for (const candidate of collectModuleCandidates("providers/all.js", "PI_AI_MODULE_PATH")) {
 		if (!existsSync(candidate)) continue;
 		try {
 			return await import(pathToFileURL(candidate).href);
@@ -222,7 +222,7 @@ async function loadPiAi() {
 	}
 
 	throw new Error(
-		`Could not load @earendil-works/pi-ai. Set PI_AI_MODULE_PATH to its dist/index.js.\nTried:\n- ${tried.join("\n- ")}`,
+		`Could not load @earendil-works/pi-ai/providers/all. Set PI_AI_MODULE_PATH to its dist/providers/all.js.\nTried:\n- ${tried.join("\n- ")}`,
 	);
 }
 
@@ -302,7 +302,7 @@ function getCachedOAuthAccess(entry, now = Date.now()) {
 }
 
 function pickFastModel(provider, requestedModel, piAi) {
-	const models = typeof piAi.getModels === "function" ? piAi.getModels(provider) : [];
+	const models = piAi.getBuiltinModels(provider);
 	if (!Array.isArray(models) || models.length === 0) {
 		if (requestedModel) return { id: requestedModel, baseUrl: undefined };
 		if (provider === "openai-codex") return { id: "gpt-5.4-mini", baseUrl: "https://chatgpt.com/backend-api" };


### PR DESCRIPTION
Previous code does not work in pi 0.85.1 .

I do not know the exact time this changed and became broken.