### PR TITLE
fix(native-web-search): Remove inaccessible models for openai-codex

### DIFF
--- a/skills/native-web-search/search.mjs
+++ b/skills/native-web-search/search.mjs
@@ -305,7 +305,7 @@ function pickFastModel(provider, requestedModel, piAi) {
 	const models = typeof piAi.getModels === "function" ? piAi.getModels(provider) : [];
 	if (!Array.isArray(models) || models.length === 0) {
 		if (requestedModel) return { id: requestedModel, baseUrl: undefined };
-		if (provider === "openai-codex") return { id: "gpt-5.4-mini", baseUrl: "https://chatgpt.com/backend-api" };
+		if (provider === "openai-codex") return { id: "gpt-5.6-luna", baseUrl: "https://chatgpt.com/backend-api" };
 		return { id: "claude-haiku-4-5", baseUrl: "https://api.anthropic.com" };
 	}
 
@@ -317,7 +317,7 @@ function pickFastModel(provider, requestedModel, piAi) {
 
 	const preferredIds =
 		provider === "openai-codex"
-			? ["gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.1", "gpt-5.1-codex-mini"]
+			? ["gpt-5.6-luna", "gpt-5.3-codex-spark", "gpt-5.5"]
 			: ["claude-haiku-4-5", "claude-3-5-haiku-latest", "claude-3-5-haiku-20241022"];
 
 	for (const id of preferredIds) {


### PR DESCRIPTION
`gpt-5.4-mini` is not available to codex users anymore, even on Pro account.

I replaced it with `luna` for first choice, and changed `5.1` which is not available to `5.5` as well.